### PR TITLE
機能追加：聞いている音楽の送信 + リファクタ

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const dotenv = require('dotenv');
-const { Client, Events, GatewayIntentBits } = require('discord.js');
+const cron = require('node-cron');
+const { Client, Events, GatewayIntentBits, cleanCodeBlockContent } = require('discord.js');
 const client = new Client({
     'intents': [
         GatewayIntentBits.Guilds,
@@ -9,6 +10,16 @@ const client = new Client({
     ]
 });
 dotenv.config();
+
+// cron job 3時間ごとに定期実行
+// TODO: messageCreateではメッセージ送信時にしか発火しないため、cronで動かすとエラーが起きるため
+//       fetchで別途messageを取るようにする。
+
+// cron.schedule('0 0 */3 * * *', () => client.on("messageCreate", (message) => {
+//     if (message.author.id === process.env.BOT_ID) {
+//         message.delete();
+//     }
+// }));
 
 
 client.on('ready', () => {
@@ -26,19 +37,52 @@ client.once(Events.ClientReady, c => {
  */
 client.on('presenceUpdate', (oldPresence, newPresence) => {
     const member = newPresence.member;
-    const userStatus = newPresence.clientStatus;
-    const userTerminalInfo = !!userStatus.desktop ? 'パソコン' : 'スマートフォン'
+    const isUser = process.env.USER_ID.includes(newPresence.userId)
+    const isUserStatus = newPresence.status
+    const isMobile = !!newPresence.clientStatus.mobile
+    let statusMessage
 
-    if (Number(newPresence.userId) === Number(process.env.USER_ID)) {
-        // ユーザーのクライアント情報を取得
-        if (newPresence.status === 'online' || newPresence.status === 'offline') {
-            let statusMessage = (userStatus.desktop === 'online' || userStatus.mobile === 'online') ? `${member.user.username} が${userTerminalInfo}でオンラインになりました。\n` : `${member.user.username} がオフラインになりました。\n`;
-            client.channels.cache.get(process.env.BOT_CHAT_ROOM_ID).send(statusMessage);
-        } else if(newPresence.status === 'idle') {
-            statusMessage = `${member.user.username} はどっかに逝きました。\n`
-            client.channels.cache.get(process.env.BOT_CHAT_ROOM_ID).send(statusMessage);
-        }
+    //　statusが同じ場合はメッセージを送信しない
+    if (!!oldPresence && oldPresence.status === newPresence.status) {
+        return
+    } else if (isUser && isUserStatus === 'online') {
+        statusMessage = `${member.user.username} が${isMobile ? 'スマートフォン' : 'パソコン'}でオンラインになりました。\n`;
+    } else if (isUser && isUserStatus === 'offline') {
+        statusMessage = `${member.user.username} がオフラインになりました。\n`
+    } else if (isUser && newPresence.status === 'idle') {
+        statusMessage = `${member.user.username} はどっかに逝きました。\n`
+    }
+
+    client.channels.cache.get(process.env.BOT_CHAT_ROOM_ID).send(statusMessage);
+});
+
+
+/**
+ * 聞いている曲をチャットに記録する
+ */
+client.on('presenceUpdate', (oldPresence, newPresence) => {
+    let isOldMusic = !!oldPresence.activities ? oldPresence.activities.find(info => info.name === 'Spotify') : null
+    let isNewMusic = !!newPresence.activities ? newPresence.activities.find(newInfo => newInfo.name === 'Spotify') : null
+
+    if (!!isNewMusic && !!isOldMusic && isOldMusic.details === isNewMusic.details) {
+        return
+    } else if (!!isNewMusic) {
+        let statusMessage = `${client.users.cache.get(newPresence.userId)}is playing MUSIC now... \n 曲名：${isNewMusic.details}　　歌手：${isNewMusic.state}`
+        client.channels.cache.get(process.env.BOT_MUSIC_HISTORY_ROOM_ID).send(statusMessage);
     }
 });
+
+/**
+ * BOTのメッセージを消す
+ * TODO：100件メッセージを取っているが、指定できるようにする
+ */
+client.on('messageCreate', async message => {
+    if (message.content === '!del') {
+        message.delete();
+        const messages = await message.channel.messages.fetch({ limit: 100 })
+        const filtered = messages.filter(message => message.author.id === process.env.BOT_ID)
+        message.channel.bulkDelete(filtered)
+    }
+})
 
 client.login(process.env.DISCORD_TOKEN);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "discord.js": "^14.11.0",
-        "dotenv": "^16.0.3"
+        "dotenv": "^16.0.3",
+        "node-cron": "^3.0.2"
       }
     },
     "node_modules/@discordjs/builders": {
@@ -255,6 +256,17 @@
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
     },
+    "node_modules/node-cron": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.2.tgz",
+      "integrity": "sha512-iP8l0yGlNpE0e6q1o185yOApANRe47UPbLf4YxfbiNHt/RU5eBcGB/e0oudruheSf+LQeDMezqC5BVAb5wwRcQ==",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/peek-readable": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
@@ -387,6 +399,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/ws": {
       "version": "8.13.0",
@@ -589,6 +609,14 @@
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
     },
+    "node-cron": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.2.tgz",
+      "integrity": "sha512-iP8l0yGlNpE0e6q1o185yOApANRe47UPbLf4YxfbiNHt/RU5eBcGB/e0oudruheSf+LQeDMezqC5BVAb5wwRcQ==",
+      "requires": {
+        "uuid": "8.3.2"
+      }
+    },
     "peek-readable": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
@@ -670,6 +698,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "ws": {
       "version": "8.13.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "discordbotv1",
   "version": "1.0.0",
-  "description": "",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -19,6 +18,8 @@
   "homepage": "https://github.com/sshunnn/discordBotV1#readme",
   "dependencies": {
     "discord.js": "^14.11.0",
-    "dotenv": "^16.0.3"
-  }
+    "dotenv": "^16.0.3",
+    "node-cron": "^3.0.2"
+  },
+  "description": ""
 }


### PR DESCRIPTION
# 概要
- 聞いている音楽情報をチャットに貼り出す機能の追加
- チャットに`!del`と入力すると入力したコマンドと過去100件のチャットからBOTが送信したメッセージが削除される機能の追加
⇒チャットに件数をして消せるようにリファクタが必要
⇒cronを使用し、定期的にBOTのメッセージを消す機能を追加してもいい。

### TODO
TODOについては基本コメントに記載。
コマンド処理については別ファイルに切り出し機能を分割するのも、いつかやる。

## リファクタ内容について
ログイン情報を送信する処理についてリファクタリングを行った。

